### PR TITLE
Removed 0x formatting from 28bit hex conversion

### DIFF
--- a/src/main/python/model/iir.py
+++ b/src/main/python/model/iir.py
@@ -45,8 +45,9 @@ def float_to_hex(f, minidsp_style, fixed_point):
     '''
     if fixed_point is True:
         # use 2s complement for negative values
+        # the 10x10HD plays no sound if 0x prefix and causes feedback if not 0 padded to 8 chars.
         val = int(-f * (2 ** 23)) ^ 0xFFFFFFF if f < 0 else int(f * (2 ** 23))
-        return f"{val:{'#' if minidsp_style is True else ''}08x}"
+        return f"{val:08x}"
     else:
         value = struct.unpack('<I', struct.pack('<f', f))[0]
         return f"{value:{'#' if minidsp_style is True else ''}010x}"


### PR DESCRIPTION
The 10x10 hardware ended up being picky about the hex values.  If the hex values are not 0 padded to 32bits it causes a feedback loop and popping.  Then if they're 32bit and contain the 0x prefix no sound is outputted.  

It appears that the only place the float_to_hex function is used is for the miniDSP merge.  If I missed a spot we might need to make it conditional over removing the formatting all together for that case. 